### PR TITLE
Resolved issue #2

### DIFF
--- a/src/main/java/at/apf/easycli/impl/EasyEngine.java
+++ b/src/main/java/at/apf/easycli/impl/EasyEngine.java
@@ -139,13 +139,17 @@ public class EasyEngine implements CliEngine {
                 cmdIndex = handleArgument(arguments, cmdIndex, params[i], paramValues, i);
             }
         }
-
         int countArgumentParameters = (int) Stream.of(method.getParameters())
                 .filter(p -> !p.isAnnotationPresent(Meta.class) && !p.isAnnotationPresent(Flag.class))
                 .count();
-        if (cmdIndex > 0 && arguments.size() > countArgumentParameters) {
+
+        System.out.println("countArgumentParameters: " + countArgumentParameters);
+        System.out.println("cmdIndex: " + cmdIndex);
+        System.out.println("arguments.size(): " + arguments.size());
+        if ((cmdIndex > 0 && arguments.size() > countArgumentParameters) || (countArgumentParameters == 0 && arguments.size() > 0)) {
             throw new MalformedCommandException("Too many arguments passed for command '" + command + "'");
         }
+
 
         method.setAccessible(true);
         return method.invoke(commands.get(command).getValue(), paramValues);

--- a/src/main/java/at/apf/easycli/impl/EasyEngine.java
+++ b/src/main/java/at/apf/easycli/impl/EasyEngine.java
@@ -143,9 +143,6 @@ public class EasyEngine implements CliEngine {
                 .filter(p -> !p.isAnnotationPresent(Meta.class) && !p.isAnnotationPresent(Flag.class))
                 .count();
 
-        System.out.println("countArgumentParameters: " + countArgumentParameters);
-        System.out.println("cmdIndex: " + cmdIndex);
-        System.out.println("arguments.size(): " + arguments.size());
         if ((cmdIndex > 0 && arguments.size() > countArgumentParameters) || (countArgumentParameters == 0 && arguments.size() > 0)) {
             throw new MalformedCommandException("Too many arguments passed for command '" + command + "'");
         }

--- a/src/test/java/at/apf/easycli/impl/EasyEngineParseTest.java
+++ b/src/test/java/at/apf/easycli/impl/EasyEngineParseTest.java
@@ -13,6 +13,7 @@ import at.apf.easycli.util.enumeration.Material;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.security.InvalidParameterException;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -373,6 +374,18 @@ public class EasyEngineParseTest {
             }
         });
         engine.parse("/add 2 3 4");
+    }
+
+
+    @Test(expected = MalformedCommandException.class)
+    public void parseParameterlessWithParameters_shouldThrowMalformedCommandException() throws Exception{
+        engine.register(new Object(){
+            @Command("/noparameter")
+            void noparameter(){
+                System.out.println("this should not be shown");
+            }
+        });
+        engine.parse("/noparameter parameter");
     }
 
 }

--- a/src/test/java/at/apf/easycli/impl/EasyEngineParseTest.java
+++ b/src/test/java/at/apf/easycli/impl/EasyEngineParseTest.java
@@ -13,7 +13,6 @@ import at.apf.easycli.util.enumeration.Material;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.security.InvalidParameterException;
 import java.util.LinkedList;
 import java.util.List;
 


### PR DESCRIPTION
Parameterless commands that were given parameters didn't throw an exception. I implemented this and created a test case to catch this scenario.